### PR TITLE
Fixing load files #6

### DIFF
--- a/src/C4Sharp/C4Sharp.csproj
+++ b/src/C4Sharp/C4Sharp.csproj
@@ -11,7 +11,8 @@
         <RepositoryUrl>https://github.com/8T4/c4sharp</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>c4, diagrams</PackageTags>
-        <PackageVersion>1.1.2</PackageVersion>
+        <PackageVersion>1.1.3</PackageVersion>
+        <PackageIconUrl>https://github.com/8T4/c4sharp/blob/main/LICENSE</PackageIconUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
Bug Reported
Doesn't download c4 files!

Alternative Fix
The fast alternative to fix this is download /bin folder from repository and folder and past in the same path that c4 folder in your project.