### PR TITLE
Make PlantumlDiagram public so that ToPumlString method is accessible

### DIFF
--- a/src/C4Sharp/Models/Plantuml/PlantumlDiagram.cs
+++ b/src/C4Sharp/Models/Plantuml/PlantumlDiagram.cs
@@ -8,7 +8,7 @@ namespace C4Sharp.Models.Plantuml
     /// <summary>
     /// Parser Diagram to PlantUML
     /// </summary>
-    internal static class PlantumlDiagram
+    public static class PlantumlDiagram
     {
         /// <summary>
         /// Create PUML content from Diagram


### PR DESCRIPTION
Make `PlantumlDiagram` public so that its `ToPumlString` method is accessible from outside of this library - it's useful for creating a puml string when you don't want to save it to a file or export it to a PNG (for example, in my project I want to post the puml string to an external server, so all I need is the string).