### PR TITLE
Optionally use a URL include instead of file include

### DIFF
--- a/src/C4Sharp/Models/Plantuml/PlantumlDiagram.cs
+++ b/src/C4Sharp/Models/Plantuml/PlantumlDiagram.cs
@@ -10,7 +10,7 @@ namespace C4Sharp.Models.Plantuml
     /// </summary>
     internal static class PlantumlDiagram
     {
-        const string stdlibBaseUrl = "https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master";
+        const string standardLibraryBaseUrl = "https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master";
 
         /// <summary>
         /// Create PUML content from Diagram
@@ -20,7 +20,7 @@ namespace C4Sharp.Models.Plantuml
         public static string ToPumlString(this Diagram diagram, bool useUrlInclude = false)
         {
             var pumlFileName = $"{diagram.Name}.puml";
-            var path = useUrlInclude ? $"{stdlibBaseUrl}/{pumlFileName}"
+            var path = useUrlInclude ? $"{standardLibraryBaseUrl}/{pumlFileName}"
                 : Path.Join(C4Directory.ResourcesFolderName, pumlFileName);
                  
             var stream = new StringBuilder();

--- a/src/C4Sharp/Models/Plantuml/PlantumlDiagram.cs
+++ b/src/C4Sharp/Models/Plantuml/PlantumlDiagram.cs
@@ -10,6 +10,8 @@ namespace C4Sharp.Models.Plantuml
     /// </summary>
     internal static class PlantumlDiagram
     {
+        const string stdlibBaseUrl = "https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master";
+
         /// <summary>
         /// Create PUML content from Diagram
         /// </summary>
@@ -18,8 +20,8 @@ namespace C4Sharp.Models.Plantuml
         public static string ToPumlString(this Diagram diagram, bool useUrlInclude = false)
         {
             var pumlFileName = $"{diagram.Name}.puml";
-            var path = useUrlInclude ? $"https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/{pumlFileName}"
-                    : Path.Join(C4Directory.ResourcesFolderName, pumlFileName);
+            var path = useUrlInclude ? $"{stdlibBaseUrl}/{pumlFileName}"
+                : Path.Join(C4Directory.ResourcesFolderName, pumlFileName);
                  
             var stream = new StringBuilder();
             stream.AppendLine($"@startuml {diagram.Slug()}");

--- a/src/C4Sharp/Models/Plantuml/PlantumlDiagram.cs
+++ b/src/C4Sharp/Models/Plantuml/PlantumlDiagram.cs
@@ -18,7 +18,7 @@ namespace C4Sharp.Models.Plantuml
         public static string ToPumlString(this Diagram diagram, bool useUrlInclude = false)
         {
             var pumlFileName = $"{diagram.Name}.puml";
-            var path = useUrlInclude ? "https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/{pumlFile}"
+            var path = useUrlInclude ? $"https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/{pumlFileName}"
                     : Path.Join(C4Directory.ResourcesFolderName, pumlFileName);
                  
             var stream = new StringBuilder();

--- a/src/C4Sharp/Models/Plantuml/PlantumlDiagram.cs
+++ b/src/C4Sharp/Models/Plantuml/PlantumlDiagram.cs
@@ -15,9 +15,11 @@ namespace C4Sharp.Models.Plantuml
         /// </summary>
         /// <param name="diagram"></param>
         /// <returns></returns>
-        public static string ToPumlString(this Diagram diagram)
+        public static string ToPumlString(this Diagram diagram, bool useUrlInclude = false)
         {
-            var path = Path.Join(C4Directory.ResourcesFolderName, $"{diagram.Name}.puml");
+            var pumlFileName = $"{diagram.Name}.puml";
+            var path = useUrlInclude ? "https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/{pumlFile}"
+                    : Path.Join(C4Directory.ResourcesFolderName, pumlFileName);
                  
             var stream = new StringBuilder();
             stream.AppendLine($"@startuml {diagram.Slug()}");


### PR DESCRIPTION
Add an optional parameter, `useUrlInclude`, to the `ToPumlString()` method. If set to true, it will change the include statement at the beginning of the puml string to link to the current PlantUML standard library file on github, instead of to a local .puml file. For example, a component diagram would have:

`!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml`

This allows for standalone PlantUML code that can be converted to a diagram by any server with an internet connection, without relying on local .puml files.

