### PR TITLE
Enable adding links to structures

### DIFF
--- a/src/C4Sharp/Models/Component.cs
+++ b/src/C4Sharp/Models/Component.cs
@@ -28,7 +28,21 @@ namespace C4Sharp.Models
         {
             Technology = technology;
         }
-        
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="alias">Unique identification</param>
+        /// <param name="label"></param>
+        /// <param name="description"></param>
+        /// <param name="technology"></param>
+        /// <param name="link"></param>
+        public Component(string alias, string label, string description, string technology, string link)
+            : base(alias, label, description, link, Boundary.Internal)
+        {
+            Technology = technology;
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -41,6 +55,21 @@ namespace C4Sharp.Models
             : base(alias, label, description, boundary)
         {
             Technology = technology;
-        }        
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="alias">Unique identification</param>
+        /// <param name="label"></param>
+        /// <param name="description"></param>
+        /// <param name="technology"></param>
+        /// <param name="link"></param>
+        /// <param name="boundary"></param>
+        public Component(string alias, string label, string description, string technology, string link, Boundary boundary)
+            : base(alias, label, description, link, boundary)
+        {
+            Technology = technology;
+        }
     }
 }

--- a/src/C4Sharp/Models/Component.cs
+++ b/src/C4Sharp/Models/Component.cs
@@ -38,7 +38,7 @@ namespace C4Sharp.Models
         /// <param name="technology"></param>
         /// <param name="link"></param>
         public Component(string alias, string label, string description, string technology, string link)
-            : base(alias, label, description, link, Boundary.Internal)
+            : base(alias, label, description, link)
         {
             Technology = technology;
         }

--- a/src/C4Sharp/Models/Container.cs
+++ b/src/C4Sharp/Models/Container.cs
@@ -47,7 +47,7 @@ namespace C4Sharp.Models
         /// <param name="technology"></param>
         /// <param name="link"></param>
         public Container(string alias, ContainerType type, string description, string technology, string link)
-            : base(alias, type.GetDescription(), description, link, Boundary.Internal)
+            : base(alias, type.GetDescription(), description, link)
         {
             Technology = technology;
             ContainerType = type;
@@ -107,7 +107,7 @@ namespace C4Sharp.Models
         /// <param name="technology"></param>
         /// <param name="link"></param>
         public Container(string alias, string label, string description, string technology, string link)
-            : base(alias, label, description, link, Boundary.Internal)
+            : base(alias, label, description, link)
         {
             Technology = technology;
             ContainerType = ContainerType.None;

--- a/src/C4Sharp/Models/Container.cs
+++ b/src/C4Sharp/Models/Container.cs
@@ -36,8 +36,23 @@ namespace C4Sharp.Models
         {
             Technology = technology;
             ContainerType = type;
-        }    
-        
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="alias">Should  be unique</param>
+        /// <param name="type"></param>
+        /// <param name="description"></param>
+        /// <param name="technology"></param>
+        /// <param name="link"></param>
+        public Container(string alias, ContainerType type, string description, string technology, string link)
+            : base(alias, type.GetDescription(), description, link, Boundary.Internal)
+        {
+            Technology = technology;
+            ContainerType = type;
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -52,7 +67,6 @@ namespace C4Sharp.Models
             Technology = technology;
             ContainerType = type;
         }
-
 
         /// <summary>
         /// Constructor
@@ -83,7 +97,22 @@ namespace C4Sharp.Models
             Technology = technology;
             ContainerType = ContainerType.None;
         }
-        
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="alias">Should  be unique</param>
+        /// <param name="label"></param>
+        /// <param name="description"></param>
+        /// <param name="technology"></param>
+        /// <param name="link"></param>
+        public Container(string alias, string label, string description, string technology, string link)
+            : base(alias, label, description, link, Boundary.Internal)
+        {
+            Technology = technology;
+            ContainerType = ContainerType.None;
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -94,6 +123,22 @@ namespace C4Sharp.Models
         /// <param name="boundary"></param>
         public Container(string alias, string label, string description, string technology, Boundary boundary) 
             : base(alias, label, description, boundary)
+        {
+            Technology = technology;
+            ContainerType = ContainerType.None;
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="alias">Should  be unique</param>
+        /// <param name="label"></param>
+        /// <param name="description"></param>
+        /// <param name="technology"></param>
+        /// <param name="link"></param>
+        /// <param name="boundary"></param>
+        public Container(string alias, string label, string description, string technology, string link, Boundary boundary)
+            : base(alias, label, description, link, boundary)
         {
             Technology = technology;
             ContainerType = ContainerType.None;

--- a/src/C4Sharp/Models/Person.cs
+++ b/src/C4Sharp/Models/Person.cs
@@ -18,7 +18,19 @@ namespace C4Sharp.Models
             : base(alias, label, description)
         {
         }
-        
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="alias">Should be unique</param>
+        /// <param name="label"></param>
+        /// <param name="description"></param>
+        /// <param name="link"></param>
+        public Person(string alias, string label, string description, string link)
+            : base(alias, label, description, link)
+        {
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -29,6 +41,19 @@ namespace C4Sharp.Models
         public Person(string alias, string label, string description, Boundary boundary) 
             : base(alias, label, description, boundary)
         {
-        }        
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="alias">Should be unique</param>
+        /// <param name="label"></param>
+        /// <param name="description"></param>
+        /// <param name="link"></param>
+        /// <param name="boundary"></param>
+        public Person(string alias, string label, string description, string link, Boundary boundary)
+            : base(alias, label, description, link, boundary)
+        {
+        }
     }
 }

--- a/src/C4Sharp/Models/Plantuml/PlantumlStructure.cs
+++ b/src/C4Sharp/Models/Plantuml/PlantumlStructure.cs
@@ -29,20 +29,16 @@ namespace C4Sharp.Models.Plantuml
         
         private static string ToPumlString(this Person person)
         {
-            var external = person.Boundary == Boundary.External
-                ? "_Ext"
-                : string.Empty;
+            var procedureName = $"Person{GetExternalSuffix(person)}";
 
-            return $"Person{external}({person.Alias}, \"{person.Label}\", \"{person.Description}\", $link=\"{person.Link}\")";
+            return $"{procedureName}({person.Alias}, \"{person.Label}\", \"{person.Description}\", $link=\"{person.Link}\")";
         }        
         
         private static string ToPumlString(this SoftwareSystem system)
         {
-            var external = system.Boundary == Boundary.External
-                ? "_Ext"
-                : string.Empty;
+            var procedureName = $"System{GetExternalSuffix(system)}";
 
-            return $"System{external}({system.Alias}, \"{system.Label}\", \"{system.Description}\", $link=\"{system.Link}\")";
+            return $"{procedureName}({system.Alias}, \"{system.Label}\", \"{system.Description}\", $link=\"{system.Link}\")";
         }        
         
         private static string ToPumlString(this SoftwareSystemBoundary boundary)
@@ -63,27 +59,23 @@ namespace C4Sharp.Models.Plantuml
         
         private static string ToPumlString(this Component component)
         {
-            var external = component.Boundary == Boundary.External
-                ? "_Ext"
-                : string.Empty;
+            var procedureName = $"Component{GetExternalSuffix(component)}";
 
-            return $"Component{external}({component.Alias}, \"{component.Label}\", \"{component.Technology}\", \"{component.Description}\", $link=\"{component.Link}\")";
+            return $"{procedureName}({component.Alias}, \"{component.Label}\", \"{component.Technology}\", \"{component.Description}\", $link=\"{component.Link}\")";
         }     
         
         private static string ToPumlString(this Container container)
         {
-            var external = container.Boundary == Boundary.External
-                ? "_Ext"
-                : string.Empty;
+            var externalSuffix = GetExternalSuffix(container);
 
-            var value = container.ContainerType switch
+            var procedureName = container.ContainerType switch
             {
-                ContainerType.Database => $"ContainerDb{external}",
-                ContainerType.Queue => $"ContainerQueue{external}",
-                _ => $"Container{external}"
+                ContainerType.Database => $"ContainerDb{externalSuffix}",
+                ContainerType.Queue => $"ContainerQueue{externalSuffix}",
+                _ => $"Container{externalSuffix}"
             };
 
-            return  $"{value}({container.Alias}, \"{container.Label}\", \"{container.Technology}\", \"{container.Description}\", $link=\"{container.Link}\")";
+            return  $"{procedureName}({container.Alias}, \"{container.Label}\", \"{container.Technology}\", \"{container.Description}\", $link=\"{container.Link}\")";
         }
 
         private static string ToPumlString(this ContainerBoundary boundary)
@@ -148,5 +140,7 @@ namespace C4Sharp.Models.Plantuml
 
             return stream.ToString();
         }
+
+        private static string GetExternalSuffix(Structure structure) => structure.Boundary == Boundary.External ? "_Ext" : string.Empty;
     }
 }

--- a/src/C4Sharp/Models/Plantuml/PlantumlStructure.cs
+++ b/src/C4Sharp/Models/Plantuml/PlantumlStructure.cs
@@ -29,18 +29,20 @@ namespace C4Sharp.Models.Plantuml
         
         private static string ToPumlString(this Person person)
         {
-            return person.Boundary == Boundary.External
-                ? $"Person_Ext({person.Alias}, \"{person.Label}\", \"{person.Description}\" )"
-                : $"Person({person.Alias}, \"{person.Label}\", \"{person.Description}\" )";
+            var external = person.Boundary == Boundary.External
+                ? "_Ext"
+                : string.Empty;
+
+            return $"Person{external}({person.Alias}, \"{person.Label}\", \"{person.Description}\", $link=\"{person.Link}\")";
         }        
         
         private static string ToPumlString(this SoftwareSystem system)
         {
-            var isExternal = system.Boundary == Boundary.External;
-            
-            return isExternal
-                ? $"System_Ext({system.Alias}, \"{system.Label}\", \"{system.Description}\")"
-                : $"System({system.Alias}, \"{system.Label}\", \"{system.Description}\")";
+            var external = system.Boundary == Boundary.External
+                ? "_Ext"
+                : string.Empty;
+
+            return $"System{external}({system.Alias}, \"{system.Label}\", \"{system.Description}\", $link=\"{system.Link}\")";
         }        
         
         private static string ToPumlString(this SoftwareSystemBoundary boundary)
@@ -61,9 +63,11 @@ namespace C4Sharp.Models.Plantuml
         
         private static string ToPumlString(this Component component)
         {
-            return component.Boundary == Boundary.External
-                ? $"Component_Ext({component.Alias}, \"{component.Label}\", \"{component.Technology}\", \"{component.Description}\" )"
-                : $"Component({component.Alias}, \"{component.Label}\", \"{component.Technology}\", \"{component.Description}\" )";
+            var external = component.Boundary == Boundary.External
+                ? "_Ext"
+                : string.Empty;
+
+            return $"Component{external}({component.Alias}, \"{component.Label}\", \"{component.Technology}\", \"{component.Description}\", $link=\"{component.Link}\")";
         }     
         
         private static string ToPumlString(this Container container)
@@ -79,7 +83,7 @@ namespace C4Sharp.Models.Plantuml
                 _ => $"Container{external}"
             };
 
-            return  $"{value}({container.Alias}, \"{container.Label}\", \"{container.Technology}\", \"{container.Description}\" )";
+            return  $"{value}({container.Alias}, \"{container.Label}\", \"{container.Technology}\", \"{container.Description}\", $link=\"{container.Link}\")";
         }
 
         private static string ToPumlString(this ContainerBoundary boundary)

--- a/src/C4Sharp/Models/SoftwareSystem.cs
+++ b/src/C4Sharp/Models/SoftwareSystem.cs
@@ -41,7 +41,7 @@ namespace C4Sharp.Models
         /// <param name="description"></param>
         /// <param name="link"></param>
         public SoftwareSystem(string alias, string label, string description, string link)
-            : base(alias, label, description, link, Boundary.Internal)
+            : base(alias, label, description, link)
         {
         }
 

--- a/src/C4Sharp/Models/SoftwareSystem.cs
+++ b/src/C4Sharp/Models/SoftwareSystem.cs
@@ -28,11 +28,23 @@ namespace C4Sharp.Models
         /// <param name="alias">Should be unique</param>
         /// <param name="label"></param>
         /// <param name="description"></param>
-        public SoftwareSystem(string alias, string label, string description) 
+        public SoftwareSystem(string alias, string label, string description)
             : base(alias, label, description, Boundary.Internal)
         {
-        }        
-        
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="alias">Should be unique</param>
+        /// <param name="label"></param>
+        /// <param name="description"></param>
+        /// <param name="link"></param>
+        public SoftwareSystem(string alias, string label, string description, string link)
+            : base(alias, label, description, link, Boundary.Internal)
+        {
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -40,9 +52,22 @@ namespace C4Sharp.Models
         /// <param name="label"></param>
         /// <param name="description"></param>
         /// <param name="boundary"></param>
-        public SoftwareSystem(string alias, string label, string description,  Boundary boundary) 
+        public SoftwareSystem(string alias, string label, string description, Boundary boundary) 
             : base(alias, label, description, boundary)
         {
-        }        
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="alias">Should be unique</param>
+        /// <param name="label"></param>
+        /// <param name="description"></param>
+        /// <param name="link"></param>
+        /// <param name="boundary"></param>
+        public SoftwareSystem(string alias, string label, string description, string link, Boundary boundary)
+            : base(alias, label, description, link, boundary)
+        {
+        }
     }
 }

--- a/src/C4Sharp/Models/Structure.cs
+++ b/src/C4Sharp/Models/Structure.cs
@@ -15,6 +15,7 @@ namespace C4Sharp.Models
         public string Label { get; }
         public string Description { get; }
         public string[] Tags { get; private set; }
+        public string Link { get; }
         public Boundary Boundary { get; }
 
         /// <summary>
@@ -40,9 +41,30 @@ namespace C4Sharp.Models
         /// <param name="alias">Should be unique</param>
         /// <param name="label"></param>
         /// <param name="description"></param>
+        /// <param name="link"></param>
+        protected Structure(string alias, string label, string description, string link) =>
+            (Alias, Label, Description, Link, Boundary) = (alias, label, description, link, Boundary.Internal);
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="alias">Should be unique</param>
+        /// <param name="label"></param>
+        /// <param name="description"></param>
         /// <param name="boundary"></param>
         protected Structure(string alias, string label, string description, Boundary boundary) =>
             (Alias, Label, Description, Boundary) = (alias, label, description, boundary);
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="alias">Should be unique</param>
+        /// <param name="label"></param>
+        /// <param name="description"></param>
+        /// <param name="link"></param>
+        /// <param name="boundary"></param>
+        protected Structure(string alias, string label, string description, string link, Boundary boundary) =>
+            (Alias, Label, Description, Link, Boundary) = (alias, label, description, link, boundary);
 
         /// <summary>
         /// Add Tags


### PR DESCRIPTION
Add a `Link` property to the `Structure` class and new structure constructors with `link` parameters, and edit the `ToPumlString()` methods so that structures in diagrams can link to URLs. For example, if you create a person with

`new Person("person1", "Person 1", "This is a person", "https://www.google.com")`,

the PUML generated will be

`Person(person1, "Person 1", "This is a person", $link="https://www.google.com")`

and, if you create an SVG out of the PUML (using another library or server), clicking on the person in the diagram will take you to Google.