### PR TITLE
Feature/add svg generation

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
     
 env:
-  VERSION: 3.0.${{ github.run_number }}
+  VERSION: 3.1.${{ github.run_number }}
   NUGET_INDEX: https://api.nuget.org/v3/index.json
   BUILD_TYPE: Release 
 

--- a/src/components/C4Sharp/C4Sharp.csproj
+++ b/src/components/C4Sharp/C4Sharp.csproj
@@ -11,7 +11,7 @@
         <RepositoryUrl>https://github.com/8T4/c4sharp</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>c4, diagrams</PackageTags>
-        <PackageVersion>2.2.1</PackageVersion>
+        <PackageVersion>3.1.0</PackageVersion>
         <PackageIconUrl>https://github.com/8T4/c4sharp/blob/main/LICENSE</PackageIconUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>

--- a/src/components/C4Sharp/Models/Plantuml/PlantumlFile.cs
+++ b/src/components/C4Sharp/Models/Plantuml/PlantumlFile.cs
@@ -1,10 +1,8 @@
-﻿using System;
+﻿using C4Sharp.Diagrams;
+using C4Sharp.FileSystem;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-using C4Sharp.Diagrams;
-using C4Sharp.FileSystem;
 
 namespace C4Sharp.Models.Plantuml
 {
@@ -48,8 +46,14 @@ namespace C4Sharp.Models.Plantuml
             
             if (session.GenerateDiagramImages)
             {
-                session.Execute(path, true);
+                session.Execute(path, true, "png");
             }
+
+            if (session.GenerateDiagramSvgImages)
+            {
+                session.Execute(path, true, "svg");
+            }
+
         }
 
         /// <summary>

--- a/src/components/C4Sharp/Models/Plantuml/PlantumlSession.cs
+++ b/src/components/C4Sharp/Models/Plantuml/PlantumlSession.cs
@@ -124,14 +124,14 @@ namespace C4Sharp.Models.Plantuml
             }
         }
 
-        private string CalculateJarCommand(bool includeLocalFiles, string generatedImageFormat, string directory)
+        private string CalculateJarCommand(bool useStandardLibrary, string generatedImageFormat, string directory)
         {
             const string includeLocalFilesArg = "-DRELATIVE_INCLUDE=\".\"";
 
-            var localFilesArg = includeLocalFiles ? includeLocalFilesArg: string.Empty;
+            var resourcesOriginArg = useStandardLibrary ? string.Empty : includeLocalFilesArg;
             var imageFormatOutputArg = string.IsNullOrWhiteSpace(generatedImageFormat) ? string.Empty: $"-t{generatedImageFormat}";
 
-            return $"-jar {FilePath} {localFilesArg} {imageFormatOutputArg} -verbose -o \"{directory}\" -charset UTF-8";
+            return $"-jar {FilePath} {resourcesOriginArg} {imageFormatOutputArg} -verbose -o \"{directory}\" -charset UTF-8";
         }
       
         /// <summary>

--- a/src/components/C4Sharp/Models/Plantuml/PlantumlSession.cs
+++ b/src/components/C4Sharp/Models/Plantuml/PlantumlSession.cs
@@ -13,6 +13,7 @@ namespace C4Sharp.Models.Plantuml
     {
         public bool StandardLibraryBaseUrl { get; private set; }
         public bool GenerateDiagramImages { get; private set; }
+        public bool GenerateDiagramSvgImages { get; private set; }
         private string FilePath { get; }
         private ProcessStartInfo ProcessInfo { get; }
 
@@ -72,12 +73,24 @@ namespace C4Sharp.Models.Plantuml
         }
 
         /// <summary>
+        /// The C4Sharp will generate *.puml files of your diagram.
+        /// Also, you could save the *.svg files using this method
+        /// </summary>
+        /// <returns></returns>
+        public PlantumlSession UseDiagramSvgImageBuilder()
+        {
+            GenerateDiagramSvgImages = true;
+            return this;
+        }
+
+        /// <summary>
         /// Execute plantuml.jar
         /// </summary>
         /// <param name="path">puml files path</param>
         /// <param name="processWholeDirectory">process all *.puml files</param>
+        /// <param name="generatedImageFormat">specifies the format of the generated images</param>
         /// <exception cref="PlantumlException"></exception>
-        internal void Execute(string path, bool processWholeDirectory)
+        internal void Execute(string path, bool processWholeDirectory, string generatedImageFormat)
         {
             var directory = processWholeDirectory
                 ? path
@@ -91,10 +104,8 @@ namespace C4Sharp.Models.Plantuml
                 }
 
                 var results = new StringBuilder();
-
-                var jar = StandardLibraryBaseUrl
-                    ? $"-jar {FilePath} -verbose -o \"{directory}\" -charset UTF-8"
-                    : $"-jar {FilePath} -DRELATIVE_INCLUDE=\".\" -verbose -o \"{directory}\" -charset UTF-8";
+                
+                var jar = CalculateJarCommand(StandardLibraryBaseUrl, generatedImageFormat, directory);
 
                 ProcessInfo.Arguments = $"{jar} {path}";
                 ProcessInfo.RedirectStandardOutput = true;
@@ -113,6 +124,16 @@ namespace C4Sharp.Models.Plantuml
             }
         }
 
+        private string CalculateJarCommand(bool includeLocalFiles, string generatedImageFormat, string directory)
+        {
+            const string includeLocalFilesArg = "-DRELATIVE_INCLUDE=\".\"";
+
+            var localFilesArg = includeLocalFiles ? includeLocalFilesArg: string.Empty;
+            var imageFormatOutputArg = string.IsNullOrWhiteSpace(generatedImageFormat) ? string.Empty: $"-t{generatedImageFormat}";
+
+            return $"-jar {FilePath} {localFilesArg} {imageFormatOutputArg} -verbose -o \"{directory}\" -charset UTF-8";
+        }
+      
         /// <summary>
         /// Clear Plantuml Resource
         /// </summary>

--- a/src/tests/C4Sharp.IntegratedTests/ExportingDiagramFixture.cs
+++ b/src/tests/C4Sharp.IntegratedTests/ExportingDiagramFixture.cs
@@ -56,7 +56,19 @@ namespace C4Sharp.IntegratedTests
 
             VerifyIfFilesExists(files);
         }
-        
+
+        protected static void VerifyIfSvgFilesExists(string diagramName, string path = "c4")
+        {
+            var files = new[]
+            {
+                Path.Join(path, $"{diagramName}-c4component.svg"),
+                Path.Join(path, $"{diagramName}-c4context.svg"),
+                Path.Join(path, $"{diagramName}-c4container.svg"),
+                Path.Join(path, $"{diagramName}-c4deployment.svg")
+            };
+
+            VerifyIfFilesExists(files);
+        }
         protected static void VerifyIfPngFilesNonExists(string diagramName, string path = "c4")
         {
             var files = new[]

--- a/src/tests/C4Sharp.IntegratedTests/ExportingDiagramFixture.cs
+++ b/src/tests/C4Sharp.IntegratedTests/ExportingDiagramFixture.cs
@@ -82,6 +82,19 @@ namespace C4Sharp.IntegratedTests
             VerifyIfFilesNonExists(files);
         }
 
+        protected static void VerifyIfSvgFilesNonExists(string diagramName, string path = "c4")
+        {
+            var files = new[]
+            {
+                Path.Join(path, $"{diagramName}-c4component.svg"),
+                Path.Join(path, $"{diagramName}-c4context.svg"),
+                Path.Join(path, $"{diagramName}-c4container.svg"),
+                Path.Join(path, $"{diagramName}-c4deployment.svg")
+            };
+
+            VerifyIfFilesNonExists(files);
+        }
+
         private static void VerifyIfFilesExists(params string[] path)
         {
             foreach (var file in path)

--- a/src/tests/C4Sharp.IntegratedTests/ExportingDiagramTests.cs
+++ b/src/tests/C4Sharp.IntegratedTests/ExportingDiagramTests.cs
@@ -10,7 +10,7 @@ namespace C4Sharp.IntegratedTests
     public class ExportingDiagramTests: ExportingDiagramFixture
     {
         [Fact]
-        public void TestExporteWithoutImages()
+        public void TestExportWithoutImages()
         {
             Setup();
             
@@ -33,7 +33,7 @@ namespace C4Sharp.IntegratedTests
         }         
         
         [Fact]
-        public void TestExportToEspecifiedPath()
+        public void TestExportToSpecifiedPath()
         {
             const string path = "c4temp";
             Setup(path);
@@ -60,7 +60,7 @@ namespace C4Sharp.IntegratedTests
         }        
         
         [Fact]
-        public void TestExportToDefaultPath()
+        public void TestExportOnlyPngToDefaultPath()
         {
             Setup();
             
@@ -80,12 +80,39 @@ namespace C4Sharp.IntegratedTests
             VerifyIfResourceFilesExists();
             VerifyIfPumlFilesExists("diagram");
             VerifyIfPngFilesExists("diagram");
-            
+            VerifyIfSvgFilesNonExists("diagram");
+
             CleanUp();
         }
 
         [Fact]
-        public void TestExportSvgToDefaultPath()
+        public void TestExportOnlySvgToDefaultPath()
+        {
+            Setup();
+
+            var diagrams = new Diagram[]
+            {
+                ContextDiagramBuilder.Build() with { Title = "Diagram" },
+                ContainerDiagramBuilder.Build() with { Title = "Diagram" },
+                ComponentDiagramBuilder.Build() with { Title = "Diagram" },
+                DeploymentDiagramBuilder.Build() with { Title = "Diagram" }
+            };
+
+
+            new PlantumlSession()
+                .UseDiagramSvgImageBuilder()
+                .Export(diagrams);
+
+            VerifyIfResourceFilesExists();
+            VerifyIfPumlFilesExists("diagram");
+            VerifyIfPngFilesNonExists("diagram");
+            VerifyIfSvgFilesExists("diagram");
+
+            CleanUp();
+        }
+
+        [Fact]
+        public void TestExportPngAndSvgToDefaultPath()
         {
             Setup();
 

--- a/src/tests/C4Sharp.IntegratedTests/ExportingDiagramTests.cs
+++ b/src/tests/C4Sharp.IntegratedTests/ExportingDiagramTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using C4Sharp.Diagrams;
 using C4Sharp.IntegratedTests.Stubs.Diagrams;
@@ -7,13 +8,16 @@ using Xunit;
 namespace C4Sharp.IntegratedTests
 {
     
-    public class ExportingDiagramTests: ExportingDiagramFixture
+    public class ExportingDiagramTests: ExportingDiagramFixture, IDisposable
     {
+        public ExportingDiagramTests()
+        {
+            Setup();
+        }
+
         [Fact]
         public void TestExportWithoutImages()
         {
-            Setup();
-            
             var diagrams = new Diagram[]
             {
                 ContextDiagramBuilder.Build() with { Title = "Diagram" },
@@ -28,8 +32,6 @@ namespace C4Sharp.IntegratedTests
             VerifyIfResourceFilesExists();
             VerifyIfPumlFilesExists("diagram");
             VerifyIfPngFilesNonExists("diagram");
-            
-            CleanUp();
         }         
         
         [Fact]
@@ -62,8 +64,6 @@ namespace C4Sharp.IntegratedTests
         [Fact]
         public void TestExportOnlyPngToDefaultPath()
         {
-            Setup();
-            
             var diagrams = new Diagram[]
             {
                 ContextDiagramBuilder.Build() with { Title = "Diagram" },
@@ -72,7 +72,6 @@ namespace C4Sharp.IntegratedTests
                 DeploymentDiagramBuilder.Build() with { Title = "Diagram" }
             };
 
-            
             new PlantumlSession()
                 .UseDiagramImageBuilder()
                 .Export(diagrams);
@@ -81,15 +80,11 @@ namespace C4Sharp.IntegratedTests
             VerifyIfPumlFilesExists("diagram");
             VerifyIfPngFilesExists("diagram");
             VerifyIfSvgFilesNonExists("diagram");
-
-            CleanUp();
         }
 
         [Fact]
         public void TestExportOnlySvgToDefaultPath()
         {
-            Setup();
-
             var diagrams = new Diagram[]
             {
                 ContextDiagramBuilder.Build() with { Title = "Diagram" },
@@ -97,7 +92,6 @@ namespace C4Sharp.IntegratedTests
                 ComponentDiagramBuilder.Build() with { Title = "Diagram" },
                 DeploymentDiagramBuilder.Build() with { Title = "Diagram" }
             };
-
 
             new PlantumlSession()
                 .UseDiagramSvgImageBuilder()
@@ -107,15 +101,11 @@ namespace C4Sharp.IntegratedTests
             VerifyIfPumlFilesExists("diagram");
             VerifyIfPngFilesNonExists("diagram");
             VerifyIfSvgFilesExists("diagram");
-
-            CleanUp();
         }
 
         [Fact]
         public void TestExportPngAndSvgToDefaultPath()
         {
-            Setup();
-
             var diagrams = new Diagram[]
             {
                 ContextDiagramBuilder.Build() with { Title = "Diagram" },
@@ -123,7 +113,6 @@ namespace C4Sharp.IntegratedTests
                 ComponentDiagramBuilder.Build() with { Title = "Diagram" },
                 DeploymentDiagramBuilder.Build() with { Title = "Diagram" }
             };
-
 
             new PlantumlSession()
                 .UseDiagramImageBuilder()
@@ -134,7 +123,10 @@ namespace C4Sharp.IntegratedTests
             VerifyIfPumlFilesExists("diagram");
             VerifyIfPngFilesExists("diagram");
             VerifyIfSvgFilesExists("diagram");
+        }
 
+        public void Dispose()
+        {
             CleanUp();
         }
     }

--- a/src/tests/C4Sharp.IntegratedTests/ExportingDiagramTests.cs
+++ b/src/tests/C4Sharp.IntegratedTests/ExportingDiagramTests.cs
@@ -83,5 +83,32 @@ namespace C4Sharp.IntegratedTests
             
             CleanUp();
         }
+
+        [Fact]
+        public void TestExportSvgToDefaultPath()
+        {
+            Setup();
+
+            var diagrams = new Diagram[]
+            {
+                ContextDiagramBuilder.Build() with { Title = "Diagram" },
+                ContainerDiagramBuilder.Build() with { Title = "Diagram" },
+                ComponentDiagramBuilder.Build() with { Title = "Diagram" },
+                DeploymentDiagramBuilder.Build() with { Title = "Diagram" }
+            };
+
+
+            new PlantumlSession()
+                .UseDiagramImageBuilder()
+                .UseDiagramSvgImageBuilder()
+                .Export(diagrams);
+
+            VerifyIfResourceFilesExists();
+            VerifyIfPumlFilesExists("diagram");
+            VerifyIfPngFilesExists("diagram");
+            VerifyIfSvgFilesExists("diagram");
+
+            CleanUp();
+        }
     }
 }


### PR DESCRIPTION
Hello there! 👋 
In our team we have been recently using the C4-Model to describe some legacy projects and the c4sharp nuget has been quite useful to our task!
Thanks a lot for this project!!! 🙇 

In the middle of this documentation task we had the need to export on svg format, and began to do it so manually, but taking a look at the c4sharp code, decided to give it a chance and create this PR, so it gets added to the nuget, if you consider so.

This change basically enables a call on the PlantumlSession class similar to `UseDiagramImageBuilder` which is `UseDiagramSvgImageBuilder`. This, in turn sets a `GenerateDiagramSvgImages` property
From there, I implemented a private builder for the jar command, so the image format argument could be added from a method parameter.
Finally, on the last commit, I also bumped the version number on the project file, and on the Github action file.

The PR can be better reviewed commit by commit.

If you have any suggestion to improve the PR, I'll be happy to receive it!

Thanks again, and happy coding! 😃 
